### PR TITLE
[네아로SDK] 버전업데이트 v5.0.1

### DIFF
--- a/Nid-OAuth/src/main/AndroidManifest.xml
+++ b/Nid-OAuth/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.nhn.android.oauth" >
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -18,12 +18,6 @@
     </queries>
 
     <application>
-
-<!--        <activity-->
-<!--            android:name="com.nhn.android.naverlogin.ui.OAuthLoginActivity"-->
-<!--            android:configChanges="orientation|screenSize"-->
-<!--            android:theme="@style/Theme.AppCompat.Light.Dialog" />-->
-
 
         <activity
             android:name="com.navercorp.nid.oauth.NidOAuthBridgeActivity"

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
@@ -3,7 +3,6 @@ package com.navercorp.nid
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import com.navercorp.nid.oauth.OAuthLoginCallback
 import com.navercorp.nid.log.NidLog
 import com.navercorp.nid.oauth.*
 
@@ -103,6 +102,19 @@ object NaverIdLoginSDK {
         } else {
             NidOAuthLogin().refreshToken(context, callback)
         }
+    }
+
+    /**
+     * 클라이언트에 저장되어 있는 Access token 및 Refresh token을 삭제함
+     */
+    fun logout() {
+        NidOAuthPreferencesManager.apply {
+            accessToken = ""
+            refreshToken = ""
+            lastErrorCode = NidOAuthErrorCode.NONE
+            lastErrorDesc = ""
+        }
+
     }
 
     /**

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/log/NidLog.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/log/NidLog.kt
@@ -13,7 +13,7 @@ import com.nhn.android.oauth.BuildConfig
  * 네아로SDK에서 사용하는 Logger 클래스
  */
 object NidLog {
-    private lateinit var instance: INidLog
+    private var instance: INidLog = ReleaseNidLog()
 
     fun init() {
         instance = if (BuildConfig.BUILD_TYPE.equals("debug", ignoreCase = true)) {

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
@@ -126,11 +126,11 @@ class NidOAuthLogin {
             } catch (t: Throwable) {
                 errorHandling(throwable = t)
                 callback.onError(-1, t.toString())
-                logout()
+                NaverIdLoginSDK.logout()
                 return@launch
             }
 
-            logout()
+            NaverIdLoginSDK.logout()
 
             var isSuccess = false
             response.body()?.let {
@@ -190,17 +190,6 @@ class NidOAuthLogin {
                 }
             }
         }
-    }
-
-    /// 클라이언트에 저장되어 있는 Access token 및 Refresh token을 삭제함
-    fun logout() {
-        NidOAuthPreferencesManager.apply {
-            accessToken = ""
-            refreshToken = ""
-            lastErrorCode = NidOAuthErrorCode.NONE
-            lastErrorDesc = ""
-        }
-
     }
 
     fun refreshToken(context: Context, callback: OAuthLoginCallback) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The NAVER Login library for Android enables you to easily add the login, logout,
 features to your application.
 
 **How to use NaverIdLogin SDK for Android? <small>(korean)</small>**
-- [Refer to Github Wiki](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.0.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C)
+- [Refer to Github Wiki](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.0.1-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C)
 - https://developers.naver.com/docs/login/android
 
 **Need help?**
@@ -47,7 +47,7 @@ Android용 네아로 SDK는 서드파티 애플리케이션에서 네이버 아�
 - https://developers.naver.com/docs/login/overview
 
 **네이버 아이디로 로그인 SDK 적용가이드**
-- [Github Wiki 가이드](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.0.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C)
+- [Github Wiki 가이드](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.0.1-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C)
 - https://developers.naver.com/docs/login/android
 
 **네이버 아이디로 로그인 문의**

--- a/Samples/build.gradle.kts
+++ b/Samples/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     /* 네아로 SDK from Project */
     implementation(project(":Nid-OAuth"))
     /* 네아로 SDK from MavenCentral */
-    implementation("com.navercorp.nid:oauth:5.0.0")
+    implementation("com.navercorp.nid:oauth:5.0.1")
 
     Dependencies.Kotlin.run {
         implementation(stdLib)

--- a/Samples/src/main/java/com/navercorp/nid/oauth/sample/LegacyActivity.kt
+++ b/Samples/src/main/java/com/navercorp/nid/oauth/sample/LegacyActivity.kt
@@ -102,7 +102,7 @@ class LegacyActivity : AppCompatActivity() {
 
         // 로그아웃
         binding.logout.setOnClickListener {
-            NidOAuthLogin().logout()
+            NaverIdLoginSDK.logout()
             updateView()
         }
 

--- a/Samples/src/main/java/com/navercorp/nid/oauth/sample/MainActivity.kt
+++ b/Samples/src/main/java/com/navercorp/nid/oauth/sample/MainActivity.kt
@@ -93,7 +93,7 @@ class MainActivity : AppCompatActivity() {
 
         // 로그아웃
         binding.logout.setOnClickListener {
-            NidOAuthLogin().logout()
+            NaverIdLoginSDK.logout()
             updateView()
         }
 
@@ -244,7 +244,7 @@ class MainActivity : AppCompatActivity() {
                         Toast.LENGTH_SHORT
                     ).show()
                 }
-                
+
                 override fun onError(errorCode: Int, message: String) {
                     onFailure(errorCode, message)
                 }

--- a/buildSrc/src/main/java/Configurations.kt
+++ b/buildSrc/src/main/java/Configurations.kt
@@ -9,8 +9,8 @@ object Configurations {
     const val minSdkVersion = 21
 
     /* Version */
-    const val moduleVersionName = "5.0.0"
-    const val moduleVersionCode = 5_00_00
+    const val moduleVersionName = "5.0.1"
+    const val moduleVersionCode = 5_00_01
 
     /* Project ClassPath */
     object Plugins {


### PR DESCRIPTION
### 변경사항
- jdk 8 버전 별도 배포
- `NidLog` 초기화 관련 오류 수정 https://github.com/naver/naveridlogin-sdk-android/issues/20
- `logout()` 메서드 위치 변경 (`NidOAuthLogin` -> NaverIdLoginSDK`)
- 가이드 문서 업데이트 https://github.com/naver/naveridlogin-sdk-android/issues/23 