### PR TITLE
fix : 네이버 로그인 초기화시 protobufException 일어나는 문제 수정

### DIFF
--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/EncryptedPreferences.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/EncryptedPreferences.kt
@@ -12,7 +12,7 @@ import com.navercorp.nid.util.AndroidVer
 
 private const val TAG = "EncryptedPreferences"
 
-private const val OAUTH_LOGIN_PREF_NAME_PER_APP  = "NaverOAuthLoginEncryptedPreferenceData";
+private const val OAUTH_LOGIN_PREF_NAME_PER_APP  = "NaverOAuthLoginEncryptedPreferenceData"
 
 object EncryptedPreferences {
 
@@ -43,7 +43,12 @@ object EncryptedPreferences {
     fun setContext(context: Context) {
         this.context = context
 
-        migration()
+        kotlin.runCatching {
+            migration()
+        }.onFailure {
+            deleteCurrentEncryptedPreference()
+            migration()
+        }
     }
 
     /**
@@ -151,6 +156,18 @@ object EncryptedPreferences {
         }
     }
 
+    private fun deleteCurrentEncryptedPreference(){
+        val preferences = getCtx().getSharedPreferences(OAUTH_LOGIN_PREF_NAME_PER_APP, Context.MODE_PRIVATE)
+
+        if (Build.VERSION.SDK_INT >= AndroidVer.API_24_NOUGAT) {
+            getCtx().deleteSharedPreferences(OLD_OAUTH_LOGIN_PREF_NAME)
+        } else {
+            preferences.edit {
+                clear()
+            }
+        }
+    }
+
     @Throws(SecurityException::class)
     private fun moveToData(preferences: SharedPreferences) {
         for (entry in preferences.all.entries) {
@@ -172,5 +189,5 @@ object EncryptedPreferences {
             }
         }
     }
-    
+
 }


### PR DESCRIPTION
안녕하세요.
네아로 SDK에서 initalize 메소드 호출시 
`com.google.crypto.tink.shaded.protobuf.InvalidProtocolBufferException` 문제가 발생하는 문제를 임시로 수정했습니다.

해당 문제는 `security-crypto:1.1.0-alpha03` 에 의해 발생하는 것으로 보이는데, ( 참고: https://github.com/google/tink/issues/413 ) 최근 alpha4 버전이 나와서 alpha4 버전으로 빌드해 보았을때도 문제가 해결되지 않아, 네아로 초기화 부분 코드를 수정하는 방법으로 해결했습니다.

디버깅 해 보았을 때,

NaverIdLoginSDK의 initialize 메소드가 EncryptedPreferences.setContext()를 호출하고,
EncryptedPreferences.setContext()에서 migration()을 호출하는 부분에서 최초에 NidOAuthPreferencesManager의 client ID를 체크하는 부분에서 protobufException이 발생하는 것을 확인해 해당 에러가 발생하는 경우 네아로 현재 버전의 ("NaverOAuthLoginEncryptedPreferenceData") 데이터를 삭제하는 식으로 우회 구현하였습니다.

해당 수정 이후 Galaxy Note 10, Z flip 3, Galaxy S9 에서 로그인 정상 동작을 확인하였습니다.



관련 이슈들은 
네아로 로그인에선
https://github.com/naver/naveridlogin-sdk-android/issues/33, https://github.com/naver/naveridlogin-sdk-android/issues/37, https://github.com/naver/naveridlogin-sdk-android/issues/38, https://github.com/naver/naveridlogin-sdk-android/issues/47, https://github.com/naver/naveridlogin-sdk-android/issues/59

트러블슈팅을 위한 Google/tink쪽 이슈는
https://github.com/google/tink/issues/413, https://github.com/google/tink/issues/504 참고해 보시면 좋을 것 같습니다.

감사합니다.