### PR TITLE
Gson proguard 누락으로 인한, CLIENT_USER_CANCEL 이슈 수정

### DIFF
--- a/Nid-OAuth/proguard-rules.pro
+++ b/Nid-OAuth/proguard-rules.pro
@@ -38,3 +38,34 @@
 -keep public class com.navercorp.nid.oauth.view.NidOAuthLoginButton {
     public *;
 }
+
+##---------------Begin: proguard configuration for Gson  ----------
+# https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+##---------------End: proguard configuration for Gson  ----------


### PR DESCRIPTION
1. 앱에 Gson proguard rule 이 추가되어 있지 않거나,
2. 다른 직렬화 라이브러리(eg. kotlinx-serialization 등)를 사용하게 되면,

minifyWithR8 과정에서 난독화 되어 최종적으로 CLIENT_USER_CANCEL 에러가 내려오게 됩니다.

연관이슈 Fixed :  #60 