### PR TITLE
[네아로SDK] 버전업데이트 v5.7.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Ver x.y.z
+이후 변경사항은 [릴리즈 노트](https://github.com/naver/naveridlogin-sdk-android/wiki/%EB%A6%B4%EB%A6%AC%EC%A6%88-%EB%85%B8%ED%8A%B8)를 참고해 주세요.
+
+---
+
 ## Ver 4.2.3
 
 ### 기능 개선

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import com.navercorp.nid.exception.NaverIdLoginSDKNotInitializedException
 import com.navercorp.nid.log.NidLog
 import com.navercorp.nid.oauth.*
 import com.navercorp.nid.preference.EncryptedPreferences
@@ -49,7 +50,28 @@ object NaverIdLoginSDK {
     /**
      * Application Context
      */
-    lateinit var applicationContext: Context
+    private var applicationContext: Context? = null
+
+    fun init(context: Context) {
+        // Application Context 저장
+        if (applicationContext == null) {
+            applicationContext = context.applicationContext
+        }
+    }
+
+    fun isInitialized(): Boolean {
+        return applicationContext != null
+    }
+
+    fun getApplicationContext(): Context {
+        val context = applicationContext
+
+        if (context != null) {
+            return context
+        } else {
+            throw NaverIdLoginSDKNotInitializedException()
+        }
+    }
 
     /**
      * OAuth 인증시 필요한 값들을 preference에 저장함. 2015년 8월 이후에 등록하여 package name 을 넣은 경우 사용.

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/exception/NaverIdLoginSDKNotInitializedException.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/exception/NaverIdLoginSDKNotInitializedException.kt
@@ -1,0 +1,6 @@
+package com.navercorp.nid.exception
+
+class NaverIdLoginSDKNotInitializedException: Exception() {
+    override val message: String
+        get() = "SDK 초기화가 필요합니다."
+}

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthBridgeActivity.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthBridgeActivity.kt
@@ -53,6 +53,11 @@ class NidOAuthBridgeActivity : AppCompatActivity() {
 
     private fun initData(): Boolean {
 
+        if (NaverIdLoginSDK.isInitialized().not()) {
+            finishWithErrorResult(NidOAuthErrorCode.SDK_IS_NOT_INITIALIZED)
+            return false
+        }
+
         if (NidOAuthPreferencesManager.clientId.isNullOrEmpty()) {
 			finishWithErrorResult(NidOAuthErrorCode.CLIENT_ERROR_NO_CLIENTID)
 			return false
@@ -83,7 +88,7 @@ class NidOAuthBridgeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         NidLog.d(TAG, "called onCreate()")
 
-        NaverIdLoginSDK.applicationContext = this.applicationContext
+        NaverIdLoginSDK.init(this)
 
         if (!initData()) {
             return

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthErrorCode.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthErrorCode.kt
@@ -36,7 +36,8 @@ enum class NidOAuthErrorCode(
     CLIENT_USER_CANCEL ("user_cancel", "user_cancel"),
     ACTIVITY_IS_SINGLE_TASK("activity_is_single_task", "activity_is_single_task"),
     WEB_VIEW_IS_DEPRECATED("web_view_is_deprecated", "web_view_is_deprecated"),
-    NO_APP_FOR_AUTHENTICATION("no_app_for_authentication", "no_app_for_authentication");
+    NO_APP_FOR_AUTHENTICATION("no_app_for_authentication", "no_app_for_authentication"),
+    SDK_IS_NOT_INITIALIZED("sdk_is_not_initialized", "sdk_is_not_initialized");
 
     companion object INSTANCE {
         fun fromString(code: String?): NidOAuthErrorCode {

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
@@ -33,7 +33,7 @@ class NidOAuthLogin {
         val response: Response<NidOAuthResponse>
         try {
             response = withContext(Dispatchers.IO) {
-                NidOAuthApi().requestAccessToken(context)
+                NidOAuthApi().requestAccessToken()
             }
         } catch (t: Throwable) {
             errorHandling(throwable = t)
@@ -82,7 +82,7 @@ class NidOAuthLogin {
         val response: Response<NidOAuthResponse>
         try {
             response = withContext(Dispatchers.IO) {
-                NidOAuthApi().requestAccessToken(context)
+                NidOAuthApi().requestAccessToken()
             }
         } catch (t: Throwable) {
             errorHandling(throwable = t)
@@ -126,12 +126,12 @@ class NidOAuthLogin {
 
     }
 
-    private suspend fun requestRefreshAccessToken(context: Context, callback: OAuthLoginCallback): String? {
+    private suspend fun requestRefreshAccessToken(callback: OAuthLoginCallback): String? {
 
         val response: Response<NidOAuthResponse>
         try {
             response = withContext(Dispatchers.IO) {
-                NidOAuthApi().requestRefreshToken(context)
+                NidOAuthApi().requestRefreshToken()
             }
         } catch (t: Throwable) {
             errorHandling(throwable = t)
@@ -167,15 +167,15 @@ class NidOAuthLogin {
         return response.body()?.accessToken
     }
 
-    fun callRefreshAccessTokenApi(context: Context, callback: OAuthLoginCallback) = CoroutineScope(Dispatchers.Main).launch {
-        requestRefreshAccessToken(context, callback)
+    fun callRefreshAccessTokenApi(callback: OAuthLoginCallback) = CoroutineScope(Dispatchers.Main).launch {
+        requestRefreshAccessToken(callback)
     }
 
-    fun callDeleteTokenApi(context: Context, callback: OAuthLoginCallback) = CoroutineScope(Dispatchers.Main).launch {
+    fun callDeleteTokenApi(callback: OAuthLoginCallback) = CoroutineScope(Dispatchers.Main).launch {
         val response: Response<NidOAuthResponse>
         try {
             response = withContext(Dispatchers.IO) {
-                NidOAuthApi().deleteToken(context)
+                NidOAuthApi().deleteToken()
             }
         } catch (t: Throwable) {
             errorHandling(throwable = t)
@@ -245,8 +245,7 @@ class NidOAuthLogin {
     }
 
     suspend fun refreshToken() = withContext(Dispatchers.Main) {
-        val context = NaverIdLoginSDK.applicationContext
-        val accessToken = requestRefreshAccessToken(context, object: OAuthLoginCallback {
+        val accessToken = requestRefreshAccessToken(object: OAuthLoginCallback {
             override fun onSuccess() {
                 NidLog.d(TAG, "requestRefreshAccessToken | onSuccess()")
             }

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthQuery.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthQuery.kt
@@ -29,12 +29,12 @@ class NidOAuthQuery {
 //        const val REQUEST_ACCESS_TOKEN_URL = "https://nid.naver.com/oauth2.0/token?"
     }
 
-    class Builder(context: Context) {
+    class Builder {
         private var method: Method? = null
         private var clientId: String? = NidOAuthPreferencesManager.clientId
         private var state: String? = NidOAuthPreferencesManager.initState
         private var callbackUrl: String? = NidOAuthPreferencesManager.callbackUrl
-        private var locale = NidDeviceUtil.getLocale(context)
+        private var locale = NidDeviceUtil.getLocale()
         private var network = NidNetworkUtil.getType()
         private var version = NidOAuthConstants.SDK_VERSION
         private var authType: String? = null

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthCustomTabActivity.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthCustomTabActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.log.NidLog
 import com.navercorp.nid.oauth.NidOAuthErrorCode
 import com.navercorp.nid.oauth.NidOAuthIntent
@@ -28,6 +29,8 @@ class NidOAuthCustomTabActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NidLog.d(TAG, "called onCreate()")
+
+        NaverIdLoginSDK.init(this)
     }
 
     override fun onResume() {
@@ -77,7 +80,11 @@ class NidOAuthCustomTabActivity : AppCompatActivity() {
     private fun openCustomTab() {
         isCustomTabOpen = true
 
-        val oauthUrl = NidOAuthQuery.Builder(this)
+        if (NaverIdLoginSDK.isInitialized().not()) {
+            responseError(null, NidOAuthErrorCode.SDK_IS_NOT_INITIALIZED.code, NidOAuthErrorCode.SDK_IS_NOT_INITIALIZED.description)
+        }
+
+        val oauthUrl = NidOAuthQuery.Builder()
             .setMethod(NidOAuthQuery.Method.CUSTOM_TABS)
             .setAuthType(intent.getStringExtra("auth_type"))
             .build()

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/api/NidOAuthApi.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/api/NidOAuthApi.kt
@@ -20,7 +20,7 @@ import retrofit2.Response
  */
 class NidOAuthApi {
 
-    suspend fun requestAccessToken(context: Context): Response<NidOAuthResponse> {
+    suspend fun requestAccessToken(): Response<NidOAuthResponse> {
 
         val clientId = NidOAuthPreferencesManager.clientId ?: ""
         val clientSecret = NidOAuthPreferencesManager.clientSecret ?: ""
@@ -35,11 +35,11 @@ class NidOAuthApi {
             state = state,
             code = code,
             version = "android-${NidOAuthConstants.SDK_VERSION}",
-            locale = NidDeviceUtil.getLocale(context)
+            locale = NidDeviceUtil.getLocale()
         )
     }
 
-    suspend fun requestRefreshToken (context: Context): Response<NidOAuthResponse> {
+    suspend fun requestRefreshToken (): Response<NidOAuthResponse> {
 
         val clientId = NidOAuthPreferencesManager.clientId ?: ""
         val clientSecret = NidOAuthPreferencesManager.clientSecret ?: ""
@@ -52,11 +52,11 @@ class NidOAuthApi {
             clientSecret = clientSecret,
             refreshToken = refreshToken,
             version = "android-${NidOAuthConstants.SDK_VERSION}",
-            locale = NidDeviceUtil.getLocale(context)
+            locale = NidDeviceUtil.getLocale()
         )
     }
 
-    suspend fun deleteToken(context: Context): Response<NidOAuthResponse> {
+    suspend fun deleteToken(): Response<NidOAuthResponse> {
 
         val clientId = NidOAuthPreferencesManager.clientId ?: ""
         val clientSecret = NidOAuthPreferencesManager.clientSecret ?: ""
@@ -69,7 +69,7 @@ class NidOAuthApi {
             clientSecret = clientSecret,
             accessToken = accessToken,
             version = "android-${NidOAuthConstants.SDK_VERSION}",
-            locale = NidDeviceUtil.getLocale(context)
+            locale = NidDeviceUtil.getLocale()
         )
     }
 

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/preference/EncryptedPreferences.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/preference/EncryptedPreferences.kt
@@ -18,7 +18,7 @@ private const val OAUTH_LOGIN_PREF_NAME_PER_APP  = "NaverOAuthLoginEncryptedPref
 object EncryptedPreferences {
 
     private var context: Context? = null
-    private fun getCtx() = context ?: NaverIdLoginSDK.applicationContext
+    private fun getCtx() = context ?: NaverIdLoginSDK.getApplicationContext()
 
     private val masterKey: MasterKey by lazy {
         MasterKey.Builder(getCtx())

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidApplicationUtil.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidApplicationUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.Build
 import androidx.browser.customtabs.CustomTabsService
@@ -122,6 +123,10 @@ object NidApplicationUtil {
             NidLog.d(TAG, e)
             -1
         }
+    }
+
+    fun getConnectivityManager(context: Context): ConnectivityManager {
+        return context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     }
 
 }

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidDeviceUtil.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidDeviceUtil.kt
@@ -2,6 +2,7 @@ package com.navercorp.nid.util
 
 import android.content.Context
 import android.os.Build
+import com.navercorp.nid.NaverIdLoginSDK
 import java.net.URLEncoder
 import java.util.*
 
@@ -20,7 +21,9 @@ object NidDeviceUtil {
     /**
      * 현재 기기의 locale 값을 반환한다.
      */
-    fun getSystemLocale(context: Context) : Locale {
+    fun getSystemLocale() : Locale {
+        val context = NaverIdLoginSDK.getApplicationContext()
+
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             context.resources.configuration.locales.get(0)
         } else {
@@ -31,8 +34,8 @@ object NidDeviceUtil {
     /**
      * 현재 기기에 지정된 언어값을 반환한다.
      */
-    fun getLocale(context: Context) : String {
-        var systemLocale = getSystemLocale(context)
+    fun getLocale() : String {
+        var systemLocale = getSystemLocale()
         if (systemLocale.toString().isEmpty()) {
             return "ko_KR"
         }
@@ -47,5 +50,5 @@ object NidDeviceUtil {
         return locale
     }
 
-    fun isKorean(context: Context) : Boolean = getSystemLocale(context).language.startsWith("ko")
+    fun isKorean() : Boolean = getSystemLocale().language.startsWith("ko")
 }

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidNetworkUtil.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/util/NidNetworkUtil.kt
@@ -2,6 +2,7 @@ package com.navercorp.nid.util
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.os.Build
 import com.navercorp.nid.NaverIdLoginSDK
 
@@ -17,27 +18,47 @@ import com.navercorp.nid.NaverIdLoginSDK
  */
 object NidNetworkUtil {
 
-    fun getType(): String {
-        var networkType = "other"
-        if (isConnected(ConnectivityManager.TYPE_MOBILE)) {
-            networkType = "cell"
-        } else if (isConnected(ConnectivityManager.TYPE_WIFI)) {
-            networkType = "wifi"
-        }
-        return networkType
+    fun getType() = if (isCellularConnected()) {
+        "cell"
+    } else if (isWifiConnected()) {
+        "wifi"
+    } else {
+        "other"
     }
 
-    fun isAvailable(): Boolean {
-        val context = NaverIdLoginSDK.applicationContext
-        val manager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        var info = manager.activeNetworkInfo
-        return info != null && info.isConnected
+    fun isAvailable() = if (Build.VERSION.SDK_INT <= AndroidVer.API_24_NOUGAT){
+        val connectivityManager = NidApplicationUtil.getConnectivityManager(NaverIdLoginSDK.getApplicationContext())
+        val info = connectivityManager.activeNetworkInfo
+        info?.isConnected == true
+    } else {
+        val connectivityManager = NidApplicationUtil.getConnectivityManager(NaverIdLoginSDK.getApplicationContext())
+        connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork) != null
     }
 
     fun isNotAvailable(): Boolean = !isAvailable()
 
+    private fun isCellularConnected() = if (Build.VERSION.SDK_INT <= AndroidVer.API_24_NOUGAT) {
+        isConnected(ConnectivityManager.TYPE_MOBILE)
+    } else {
+        val connectivityManager = NidApplicationUtil.getConnectivityManager(NaverIdLoginSDK.getApplicationContext())
+
+        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+
+        capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true
+    }
+
+    private fun isWifiConnected() = if (Build.VERSION.SDK_INT <= AndroidVer.API_24_NOUGAT) {
+        isConnected(ConnectivityManager.TYPE_WIFI)
+    } else {
+        val connectivityManager = NidApplicationUtil.getConnectivityManager(NaverIdLoginSDK.getApplicationContext())
+
+        val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+
+        capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+    }
+
     private fun isConnected(connectType: Int): Boolean {
-        val context = NaverIdLoginSDK.applicationContext
+        val context = NaverIdLoginSDK.getApplicationContext()
         val manager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         if (manager != null) {
             if (Build.VERSION.SDK_INT < AndroidVer.API_23_MARSHMALLOW) {

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/util/UserAgentFactory.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/util/UserAgentFactory.kt
@@ -44,7 +44,7 @@ object UserAgentFactory {
     private fun generateAppInfo(): String? {
         var appInfo: String? = null
         try {
-            val context = NaverIdLoginSDK.applicationContext
+            val context = NaverIdLoginSDK.getApplicationContext()
             val packageManger = context.packageManager
             val packageInfo = packageManger.getPackageInfo(
                 context.packageName,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The NAVER Login library for Android enables you to easily add the login, logout,
 features to your application.
 
 **How to use NaverIdLogin SDK for Android? <small>(korean)</small>**
-- [Refer to Github Wiki](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.3.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C-(%EC%B5%9C%EC%8B%A0-v5.6.0))
+- [Refer to Github Wiki](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.7.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C-(%EC%B5%9C%EC%8B%A0-v5.7.0))
 - https://developers.naver.com/docs/login/android
 
 **Need help?**
@@ -29,7 +29,7 @@ Naver Login for Android uses libraries below.
 - androidx.browser:browser:1.0.0
 - androidx.legacy:legacy-support-v4:1.0.0
 - androidx.constraintlayout:constraintlayout:1.1.3
-- androidx.security:security-crypto:1.1.0-alpha05
+- androidx.security:security-crypto:1.1.0-alpha06
 - androidx.core:core-ktx:1.3.0
 - androidx.fragment:fragment-ktx:1.3.6
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0
@@ -49,7 +49,7 @@ Android용 네아로 SDK는 서드파티 애플리케이션에서 네이버 아�
 - https://developers.naver.com/docs/login/overview
 
 **네이버 아이디로 로그인 SDK 적용가이드**
-- [Github Wiki 가이드](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.3.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C-(%EC%B5%9C%EC%8B%A0-v5.6.0))
+- [Github Wiki 가이드](https://github.com/naver/naveridlogin-sdk-android/wiki/v5.7.0-%EC%9D%B4%EC%83%81-%EA%B0%80%EC%9D%B4%EB%93%9C-(%EC%B5%9C%EC%8B%A0-v5.7.0))
 - https://developers.naver.com/docs/login/android
 
 **네이버 아이디로 로그인 문의**
@@ -66,7 +66,7 @@ Android용 네아로 SDK는 서드파티 애플리케이션에서 네이버 아�
 - androidx.browser:browser:1.0.0
 - androidx.legacy:legacy-support-v4:1.0.0
 - androidx.constraintlayout:constraintlayout:1.1.3
-- androidx.security:security-crypto:1.1.0-alpha05
+- androidx.security:security-crypto:1.1.0-alpha06
 - androidx.core:core-ktx:1.3.0
 - androidx.fragment:fragment-ktx:1.3.6 
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0

--- a/Samples/src/main/AndroidManifest.xml
+++ b/Samples/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
+        android:name=".OAuthApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/Samples/src/main/java/com/navercorp/nid/oauth/sample/MainActivity.kt
+++ b/Samples/src/main/java/com/navercorp/nid/oauth/sample/MainActivity.kt
@@ -128,7 +128,7 @@ class MainActivity : AppCompatActivity() {
 
         // 연동 끊기
         binding.deleteToken.setOnClickListener {
-            NidOAuthLogin().callDeleteTokenApi(context, object : OAuthLoginCallback {
+            NidOAuthLogin().callDeleteTokenApi(object : OAuthLoginCallback {
                 override fun onSuccess() {
                     updateView()
                 }
@@ -152,7 +152,7 @@ class MainActivity : AppCompatActivity() {
 
         // 토큰 갱신
         binding.refreshToken.setOnClickListener {
-            NidOAuthLogin().callRefreshAccessTokenApi(context, object : OAuthLoginCallback {
+            NidOAuthLogin().callRefreshAccessTokenApi(object : OAuthLoginCallback {
                 override fun onSuccess() {
                     updateView()
                 }

--- a/Samples/src/main/java/com/navercorp/nid/oauth/sample/OAuthApplication.kt
+++ b/Samples/src/main/java/com/navercorp/nid/oauth/sample/OAuthApplication.kt
@@ -1,0 +1,18 @@
+package com.navercorp.nid.oauth.sample
+
+import android.app.Application
+import android.widget.Toast
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.log.NidLog
+
+class OAuthApplication: Application() {
+
+    companion object {
+        const val TAG = "OAuthApplication"
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        NaverIdLoginSDK.init(this)
+    }
+}

--- a/buildSrc/src/main/java/Configurations.kt
+++ b/buildSrc/src/main/java/Configurations.kt
@@ -5,12 +5,12 @@ object Configurations {
     /* Module */
     const val compileSdkVersion = 33
     const val buildToolsVersion = "30.0.2"
-    const val targetSdkVersion = 31
+    const val targetSdkVersion = 33
     const val minSdkVersion = 21
 
     /* Version */
-    const val moduleVersionName = "5.6.0"
-    const val moduleVersionCode = 5_06_00
+    const val moduleVersionName = "5.7.0"
+    const val moduleVersionCode = 5_07_00
 
     /* Project ClassPath */
     object Plugins {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -12,7 +12,7 @@ object Dependencies {
         const val browser = "androidx.browser:browser:$androidxVersion"
         const val supportV4 = "androidx.legacy:legacy-support-v4:$androidxVersion"
         const val constraintLayout = "androidx.constraintlayout:constraintlayout:1.1.3"
-        const val crypto = "androidx.security:security-crypto:1.1.0-alpha05"
+        const val crypto = "androidx.security:security-crypto:1.1.0-alpha06"
         const val coreKtx = "androidx.core:core-ktx:1.3.0"
         const val fragmentKtx = "androidx.fragment:fragment-ktx:1.3.6"
         const val lifecycleViewModel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0"


### PR DESCRIPTION
### 변경사항
- targetSdk 버전업데이트 31 -> 33
- androidx security-crypto 버전 업데이트 1.1.0-alpha05 -> 1.1.0-alpha06
- NidNetworkUtil 개선
- lateinit 키워드 제거
- UninitializedPropertyAccessException 이슈 해소 naver/naveridlogin-sdk-android#91