### PR TITLE
Do not misuse `CoroutineScope`

### DIFF
--- a/Nid-OAuth/src/main/java/com/navercorp/nid/NidOAuth.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/NidOAuth.kt
@@ -26,11 +26,9 @@ import com.navercorp.nid.profile.domain.usecase.FetchUserProfile
 import com.navercorp.nid.profile.domain.vo.NidProfile
 import com.navercorp.nid.profile.domain.vo.NidProfileMap
 import com.navercorp.nid.profile.util.NidProfileCallback
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -65,18 +63,6 @@ object NidOAuth {
     private val setUpOauthInfo by lazy {
         SetUpOAuthInfo(oauthRepository)
     }
-
-    /**
-     * 에러 핸들러가 포함된 IO 스코프
-     */
-    fun createErrorHandlingIoScope(
-        errorHandle: ((Throwable) -> Unit)? = null,
-    ) = CoroutineScope(Dispatchers.IO + CoroutineExceptionHandler { _, throwable ->
-        NidLog.e(TAG, "CoroutineExceptionHandler got $throwable")
-        CoroutineScope(Dispatchers.Main).launch {
-            errorHandle?.invoke(throwable)
-        }
-    })
 
     /**
      * 네이버앱에 대한 market link 팝업의 노출 여부 결정
@@ -160,40 +146,42 @@ object NidOAuth {
         clientSecret: String,
         clientName: String,
         initCallback: NidOAuthInitializingCallback?,
-    ) = createErrorHandlingIoScope(
-        errorHandle = { throwable ->
+    ) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            // 데이터 초기화 진행 세팅
+            _isDataInitializing.set(true)
+
+            // 이미 초기화된 경우, 재초기화하지 않음
+            dataInitializingMutex.withLock {
+                // 1. 데이터 마이그레이션 수행
+                // SharedPreferences/EncryptedPreferences -> DataStore
+                // 마이그레이션 실패해도 내부적으로 에러 처리, 전파 x
+                NidDataMigrationManager.migrateDataFromLegacyStores()
+
+                // 2. 데이터 초기화
+                // 마이그레이션 실패 여부와 상관없이 초기 데이터가 새롭게 저장
+                // 마이그레이션 성공할 경우 기존 데이터 유지 / 실패할 경우 다시 OAuth 인증 필요
+                setUpOauthInfo.initData(
+                    clientId = clientId,
+                    clientSecret = clientSecret,
+                    clientName = clientName,
+                    callbackUrl = context.packageName,
+                    lastErrorCode = NidOAuthErrorCode.NONE.code,
+                    lastErrorDesc = "",
+                )
+            }
+
+            // 데이터 초기화 완료 세팅
             _isDataInitializing.set(false)
-            initCallback?.onFailure(throwable as Exception)
-        }
-    ).launch {
-        // 데이터 초기화 진행 세팅
-        _isDataInitializing.set(true)
-
-        // 이미 초기화된 경우, 재초기화하지 않음
-        dataInitializingMutex.withLock {
-            // 1. 데이터 마이그레이션 수행
-            // SharedPreferences/EncryptedPreferences -> DataStore
-            // 마이그레이션 실패해도 내부적으로 에러 처리, 전파 x
-            NidDataMigrationManager.migrateDataFromLegacyStores()
-
-            // 2. 데이터 초기화
-            // 마이그레이션 실패 여부와 상관없이 초기 데이터가 새롭게 저장
-            // 마이그레이션 성공할 경우 기존 데이터 유지 / 실패할 경우 다시 OAuth 인증 필요
-            setUpOauthInfo.initData(
-                clientId = clientId,
-                clientSecret = clientSecret,
-                clientName = clientName,
-                callbackUrl = context.packageName,
-                lastErrorCode = NidOAuthErrorCode.NONE.code,
-                lastErrorDesc = "",
-            )
-        }
-
-        // 데이터 초기화 완료 세팅
-        _isDataInitializing.set(false)
-        withContext(Dispatchers.Main) {
-            initCallback?.onSuccess()
-            registerProcessLifecycleOwner()
+            withContext(Dispatchers.Main) {
+                initCallback?.onSuccess()
+                registerProcessLifecycleOwner()
+            }
+        } catch (throwable: Throwable) {
+            withContext(Dispatchers.Main) {
+                _isDataInitializing.set(false)
+                initCallback?.onFailure(throwable as Exception)
+            }
         }
     }
 
@@ -340,13 +328,17 @@ object NidOAuth {
      */
     fun logout(
         callback: NidOAuthCallback,
-    ) = createErrorHandlingIoScope { throwable ->
-        val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
-        callback.onFailure(executionError.code, throwable.message ?: executionError.description)
-    }.launch {
-        logout.invoke()
-        withContext(Dispatchers.Main) {
-            callback.onSuccess()
+    ) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            logout.invoke()
+            withContext(Dispatchers.Main) {
+                callback.onSuccess()
+            }
+        } catch (throwable: Throwable) {
+            withContext(Dispatchers.Main) {
+                val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
+                callback.onFailure(executionError.code, throwable.message ?: executionError.description)
+            }
         }
     }
 
@@ -491,23 +483,27 @@ object NidOAuth {
      */
     fun disconnect(
         callback: NidOAuthCallback
-    ) = createErrorHandlingIoScope { throwable ->
-        val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
-        callback.onFailure(executionError.code, throwable.message ?: executionError.description)
-    }.launch {
-        val disconnectResult = disconnect()
-        if (!disconnectResult.isDisconnectSuccess) {
-            setUpOauthInfo.setUpLastErrorInfo(
-                errorCode = disconnectResult.error.code,
-                errorDesc = disconnectResult.errorDescription
-            )
-            withContext(Dispatchers.Main) {
-                callback.onFailure(disconnectResult.error.code, disconnectResult.errorDescription)
+    ) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            val disconnectResult = disconnect()
+            if (!disconnectResult.isDisconnectSuccess) {
+                setUpOauthInfo.setUpLastErrorInfo(
+                    errorCode = disconnectResult.error.code,
+                    errorDesc = disconnectResult.errorDescription
+                )
+                withContext(Dispatchers.Main) {
+                    callback.onFailure(disconnectResult.error.code, disconnectResult.errorDescription)
+                }
+            } else {
+                logout()
+                withContext(Dispatchers.Main) {
+                    callback.onSuccess()
+                }
             }
-        } else {
-            logout()
+        } catch (throwable: Throwable) {
             withContext(Dispatchers.Main) {
-                callback.onSuccess()
+                val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
+                callback.onFailure(executionError.code, throwable.message ?: executionError.description)
             }
         }
     }
@@ -519,17 +515,21 @@ object NidOAuth {
      */
     fun getUserProfile(
         callback: NidProfileCallback<NidProfile>
-    ) = createErrorHandlingIoScope { throwable ->
-        val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
-        callback.onFailure(executionError.code, throwable.message ?: executionError.description)
-    }.launch {
-        val accessToken = getOAuthInfo.getAccessToken().orEmpty()
-        val profileResult = fetchUserProfile.getUserProfile(accessToken)
-        withContext(Dispatchers.Main) {
-            if (profileResult.isValid) {
-                callback.onSuccess(profileResult)
-            } else {
-                callback.onFailure(profileResult.error.code, profileResult.errorDescription)
+    ) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            val accessToken = getOAuthInfo.getAccessToken().orEmpty()
+            val profileResult = fetchUserProfile.getUserProfile(accessToken)
+            withContext(Dispatchers.Main) {
+                if (profileResult.isValid) {
+                    callback.onSuccess(profileResult)
+                } else {
+                    callback.onFailure(profileResult.error.code, profileResult.errorDescription)
+                }
+            }
+        } catch (throwable: Throwable) {
+            withContext(Dispatchers.Main) {
+                val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
+                callback.onFailure(executionError.code, throwable.message ?: executionError.description)
             }
         }
     }
@@ -541,17 +541,21 @@ object NidOAuth {
      */
     fun getUserProfileMap(
         callback: NidProfileCallback<NidProfileMap>
-    ) = createErrorHandlingIoScope { throwable ->
-        val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
-        callback.onFailure(executionError.code, throwable.message ?: executionError.description)
-    }.launch {
-        val accessToken = getOAuthInfo.getAccessToken().orEmpty()
-        val profileMapResult = fetchUserProfile.getUserProfileMap(accessToken)
-        withContext(Dispatchers.Main) {
-            if (profileMapResult.isValid) {
-                callback.onSuccess(profileMapResult)
-            } else {
-                callback.onFailure(profileMapResult.error.code, profileMapResult.errorDescription)
+    ) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            val accessToken = getOAuthInfo.getAccessToken().orEmpty()
+            val profileMapResult = fetchUserProfile.getUserProfileMap(accessToken)
+            withContext(Dispatchers.Main) {
+                if (profileMapResult.isValid) {
+                    callback.onSuccess(profileMapResult)
+                } else {
+                    callback.onFailure(profileMapResult.error.code, profileMapResult.errorDescription)
+                }
+            }
+        } catch (throwable: Throwable) {
+            withContext(Dispatchers.Main) {
+                val executionError = NidOAuthErrorCode.SDK_EXECUTION_ERROR
+                callback.onFailure(executionError.code, throwable.message ?: executionError.description)
             }
         }
     }

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
@@ -8,9 +8,8 @@ import com.navercorp.nid.oauth.util.NidOAuthCallback
 import com.navercorp.nid.profile.domain.vo.NidProfile
 import com.navercorp.nid.profile.domain.vo.NidProfileMap
 import com.navercorp.nid.profile.util.NidProfileCallback
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -19,23 +18,22 @@ class NidOAuthLogin {
         Login(NidServiceLocator.provideOAuthRepository())
     }
 
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        NidLog.e(TAG, "CoroutineExceptionHandler $throwable")
-    }
-    private val ioScope = CoroutineScope(Dispatchers.IO + coroutineExceptionHandler)
-
     @Deprecated(
         message = "This method will be removed from v6.1.0. Use NidOAuth.requestLogin(cotext, callback) instead.",
         replaceWith = ReplaceWith("NidOAuth.requestLogin(context, callback)"),
     )
-    fun callRefreshAccessTokenApi(callback: NidOAuthCallback) = ioScope.launch {
-        val oauthToken = login.refreshToken()
-        withContext(Dispatchers.Main) {
-            if (oauthToken.isOAuthSuccess) {
-                callback.onSuccess()
-            } else {
-                callback.onFailure(oauthToken.error.code, oauthToken.errorDescription)
+    fun callRefreshAccessTokenApi(callback: NidOAuthCallback) = GlobalScope.launch(Dispatchers.IO) {
+        try {
+            val oauthToken = login.refreshToken()
+            withContext(Dispatchers.Main) {
+                if (oauthToken.isOAuthSuccess) {
+                    callback.onSuccess()
+                } else {
+                    callback.onFailure(oauthToken.error.code, oauthToken.errorDescription)
+                }
             }
+        } catch (throwable: Throwable) {
+            NidLog.e(TAG, "CoroutineExceptionHandler $throwable")
         }
     }
 

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthBridgeActivity.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthBridgeActivity.kt
@@ -22,8 +22,8 @@ import com.navercorp.nid.oauth.domain.vo.LoginInfo
 import com.navercorp.nid.oauth.view.NidProgressDialog
 import com.navercorp.nid.oauth.viewModel.NidOAuthBridgeViewModel
 import com.nhn.android.oauth.R
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 /**
@@ -223,7 +223,7 @@ class NidOAuthBridgeActivity : AppCompatActivity() {
 
     private fun requestLogin(
         data: Intent?,
-    ) = CoroutineScope(Dispatchers.Main).launch {
+    ) = GlobalScope.launch(Dispatchers.Main) {
         if (data == null) {
             finishWithErrorResult(NidOAuthErrorCode.CLIENT_USER_CANCEL)
             return@launch
@@ -341,7 +341,7 @@ class NidOAuthBridgeActivity : AppCompatActivity() {
     private fun setUpLastErrorInfo(
         errorCode: String,
         errorDesc: String,
-    ) = CoroutineScope(Dispatchers.IO).launch {
+    ) = GlobalScope.launch(Dispatchers.IO) {
         try {
             setUpOAuthInfo.setUpLastErrorInfo(
                 errorCode = errorCode,

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthCustomTabActivity.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthCustomTabActivity.kt
@@ -9,8 +9,8 @@ import androidx.lifecycle.lifecycleScope
 import com.navercorp.nid.NidOAuth
 import com.navercorp.nid.core.data.errorcode.NidOAuthErrorCode
 import com.navercorp.nid.core.log.NidLog
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
@@ -38,7 +38,7 @@ class NidOAuthCustomTabActivity : AppCompatActivity() {
         super.onResume()
 
         if (isCustomTabOpen) {
-            CoroutineScope(Dispatchers.Main).launch {
+            GlobalScope.launch(Dispatchers.Main) {
                 delay(500)
                 if (!isCalledNewIntent) {
                     responseError(null, NidOAuthErrorCode.CLIENT_USER_CANCEL.code, NidOAuthErrorCode.CLIENT_USER_CANCEL.description)

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/viewModel/NidOAuthBridgeViewModel.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/viewModel/NidOAuthBridgeViewModel.kt
@@ -10,9 +10,8 @@ import com.navercorp.nid.oauth.domain.usecase.Login
 import com.navercorp.nid.oauth.domain.vo.LoginInfo
 import com.navercorp.nid.oauth.domain.vo.Token
 import com.navercorp.nid.oauth.util.NidOAuthCallback
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -22,16 +21,6 @@ class NidOAuthBridgeViewModel : ViewModel() {
             oauthRepository = NidServiceLocator.provideOAuthRepository()
         )
     }
-
-    /**
-     * 에러 핸들러가 포함된 IO 스코프
-     */
-    fun createErrorHandlingIoScope(
-        errorHandle: ((Throwable) -> Unit)? = null,
-    ) = CoroutineScope(Dispatchers.IO + CoroutineExceptionHandler { _, throwable ->
-        NidLog.e(TAG, "CoroutineExceptionHandler got $throwable")
-        errorHandle?.invoke(throwable)
-    })
 
     /**
      * ProgressBar 표시 여부 LiveData
@@ -97,19 +86,20 @@ class NidOAuthBridgeViewModel : ViewModel() {
             }
         }
 
-        createErrorHandlingIoScope(
-            errorHandle = { throwable ->
+        GlobalScope.launch(Dispatchers.IO) {
+            try {
+                _isShowProgress.postValue(true)
+                val oauthToken = login.refreshToken()
+
+                if (oauthToken.isOAuthSuccess) {
+                    oauthLoginCallback.onSuccess()
+                } else {
+                    oauthLoginCallback.onFailure(oauthToken.error.code, oauthToken.errorDescription)
+                }
+            } catch (throwable: Throwable) {
+                NidLog.e(TAG, "CoroutineExceptionHandler got $throwable")
                 val unknownError = NidOAuthErrorCode.ERROR_NO_CATAGORIZED
                 oauthLoginCallback.onFailure(unknownError.code, unknownError.description)
-            }
-        ).launch {
-            _isShowProgress.postValue(true)
-            val oauthToken = login.refreshToken()
-
-            if (oauthToken.isOAuthSuccess) {
-                oauthLoginCallback.onSuccess()
-            } else {
-                oauthLoginCallback.onFailure(oauthToken.error.code, oauthToken.errorDescription)
             }
         }
     }


### PR DESCRIPTION
The SDK severely misuses the `CoroutineScope`.

I'll just copy a paragraph from the [Coroutines docs](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-global-scope/):

> ## GlobalScope vs. Custom CoroutineScope
>
> Do not replace `GlobalScope.launch { ... }` with `CoroutineScope().launch { ... }` constructor function call. The latter has the same pitfalls as `GlobalScope`. See [CoroutineScope](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/index.html) documentation on the intended usage of `CoroutineScope()` constructor function.

Basically, if you never `cancel()` the manually created `CoroutineScope`, you are doing something wrong.