### PR TITLE
Fix multiple invocations of oauthLoginCallback in NidOAuthBridgeActivity

### DIFF
--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthBridgeActivity.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/activity/NidOAuthBridgeActivity.kt
@@ -223,27 +223,29 @@ class NidOAuthBridgeActivity : AppCompatActivity() {
 
     private fun requestLogin(
         data: Intent?,
-    ) = CoroutineScope(Dispatchers.Main).launch {
-        if (data == null) {
-            finishWithErrorResult(NidOAuthErrorCode.CLIENT_USER_CANCEL)
-            return@launch
-        }
+    ) {
+        lifecycleScope.launch {
+            if (data == null) {
+                finishWithErrorResult(NidOAuthErrorCode.CLIENT_USER_CANCEL)
+                return@launch
+            }
 
-        val state = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_STATE)
-        val code = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_CODE)
-        val errorCode = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_ERROR_CODE)
-        val errorDescription = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_ERROR_DESCRIPTION)
-        val loginInfo = LoginInfo(
-            oauthCode = code,
-            oauthState = state,
-            errorCode = errorCode,
-            errorDesc = errorDescription
-        )
+            val state = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_STATE)
+            val code = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_CODE)
+            val errorCode = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_ERROR_CODE)
+            val errorDescription = data.getStringExtra(NidOAuthIntent.Companion.OAUTH_RESULT_ERROR_DESCRIPTION)
+            val loginInfo = LoginInfo(
+                oauthCode = code,
+                oauthState = state,
+                errorCode = errorCode,
+                errorDesc = errorDescription
+            )
 
-        if (code.isNullOrEmpty()) {
-            finishWithErrorResult(data)
-        } else {
-            login(loginInfo)
+            if (code.isNullOrEmpty()) {
+                finishWithErrorResult(data)
+            } else {
+                login(loginInfo)
+            }
         }
     }
 


### PR DESCRIPTION
This one needs a bit more explanation.

Because you use a custom `CoroutineScope` which is never cancelled, the coroutine will continue running even after the Activity is destroyed.

This breaks expectations about the `NidOAuthCallback` callback. It is possible to receive both `onSuccess()` and `onFailure(...)` callbacks for the same login attempt.

---

If a configuration change occurs during the login process, the `NidOAuthBridgeActivity` gets destroyed and the `NidOAuth.oauthLoginCallback?.onFailure(...)` is invoked:

```kt
    override fun onDestroy() {
        super.onDestroy()
        NidLog.d(TAG, "called onDestroy()")

        if (viewModel.getIsForceDestroyed() && !viewModel.getIsRotated()) {
            val errorCode = NidOAuthErrorCode.ACTIVITY_IS_SINGLE_TASK
            setUpLastErrorInfo(
                errorCode = errorCode.code,
                errorDesc = "OAuthLoginActivity is destroyed.",
            )

            NidOAuth.oauthLoginCallback?.onFailure(errorCode.code, "OAuthLoginActivity is destroyed.")
            setResult(RESULT_CANCELED)
        }
    }
```

This triggers: `"activity_is_single_task", "OAuthLoginActivity is destroyed"`.

```
D  java.lang.Throwable
   	at net.bucketplace.feature.intro.snslogin.provider.naver.NaverLoginProviderKt$nidOAuthCoroutine$2$1.onFailure(NaverLoginProvider.kt:97)
   	at com.navercorp.nid.oauth.activity.NidOAuthBridgeActivity.onDestroy(NidOAuthBridgeActivity.kt:310)
   	at android.app.Activity.performDestroy(Activity.java:9384)
   	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1566)
   	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:6108)
   	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:6153)
   	at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:6438)
   	at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:6353)
   	at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:106)
   	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:63)
   	at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:133)
   	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:103)
   	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
   	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2773)
   	at android.os.Handler.dispatchMessage(Handler.java:109)
   	at android.os.Looper.loopOnce(Looper.java:232)
   	at android.os.Looper.loop(Looper.java:317)
   	at android.app.ActivityThread.main(ActivityThread.java:8934)
   	at java.lang.reflect.Method.invoke(Native Method)
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
   	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```

This is fine.

---

However, because the `CoroutineScope` created in the `requestLogin` method keeps running even after the Activity is destroyed, it eventually reaches the `private suspend fun login()` where it invokes the `callback.onSuccess()`:

```kt
private suspend fun login(
    loginInfo: LoginInfo,
) {
    val progressDialog = NidProgressDialog(this@NidOAuthBridgeActivity)
    progressDialog.showProgress(R.string.naveroauthlogin_string_getting_token)

    val callback = NidOAuth.oauthLoginCallback
    if (callback != null) {
        val oauthToken = viewModel.requestLogin(loginInfo)
        if (oauthToken.isOAuthInterrupted || !oauthToken.isOAuthSuccess) {
            callback.onFailure(oauthToken.error.code, oauthToken.errorDescription)
        } else {
            callback.onSuccess()
        }
    }
    
    ...
}
```

```
D  java.lang.Throwable
   	at net.bucketplace.feature.intro.snslogin.provider.naver.NaverLoginProviderKt$nidOAuthCoroutine$2$1.onSuccess(NaverLoginProvider.kt:93)
   	at com.navercorp.nid.oauth.activity.NidOAuthBridgeActivity.login(NidOAuthBridgeActivity.kt:268)
   	at com.navercorp.nid.oauth.activity.NidOAuthBridgeActivity.access$login(NidOAuthBridgeActivity.kt:40)
   	at com.navercorp.nid.oauth.activity.NidOAuthBridgeActivity$login$1.invokeSuspend(Unknown Source:15)
   	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
   	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
   	at android.os.Handler.handleCallback(Handler.java:991)
   	at android.os.Handler.dispatchMessage(Handler.java:102)
   	at android.os.Looper.loopOnce(Looper.java:232)
   	at android.os.Looper.loop(Looper.java:317)
   	at android.app.ActivityThread.main(ActivityThread.java:8934)
   	at java.lang.reflect.Method.invoke(Native Method)
   	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
   	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```

This is not fine.

---

Scoping the coroutine to the lifecycle of the Activity should prevent the coroutine from running after a `onFailure` has been invoked on the callback.

---


https://github.com/user-attachments/assets/d0265942-0696-47ad-baac-6debd266c78f


