### PR TITLE
Fix broken @Deprecated ReplaceWith on showDevelopersLog, plus typos in comments and docs

### DIFF
--- a/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt
@@ -110,8 +110,8 @@ object NaverIdLoginSDK {
      * @param show if true, show detail-log.
      */
     @Deprecated(
-        message = "This method will be removed from v6.1.0. Use NidOAuth.showDevelopersLog(isShow) instead.",
-        replaceWith = ReplaceWith("NidOAuth.setLOgEnabled(enabled)"),
+        message = "This method will be removed from v6.1.0. Use NidOAuth.setLogEnabled(isShow) instead.",
+        replaceWith = ReplaceWith("NidOAuth.setLogEnabled(isShow)"),
     )
     fun showDevelopersLog(isShow: Boolean) = NidOAuth.setLogEnabled(isShow)
 

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/core/log/ReleaseNidLog.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/core/log/ReleaseNidLog.kt
@@ -19,26 +19,26 @@ class ReleaseNidLog : INidLog {
     }
 
     override fun v(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 
     override fun d(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 
     override fun i(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 
     override fun w(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 
     override fun e(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 
     override fun wtf(tag: String, message: String) {
-        // Do nothings.
+        // Do nothing.
     }
 }

--- a/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
+++ b/Nid-OAuth/src/main/java/com/navercorp/nid/oauth/NidOAuthLogin.kt
@@ -25,7 +25,7 @@ class NidOAuthLogin {
     private val ioScope = CoroutineScope(Dispatchers.IO + coroutineExceptionHandler)
 
     @Deprecated(
-        message = "This method will be removed from v6.1.0. Use NidOAuth.requestLogin(cotext, callback) instead.",
+        message = "This method will be removed from v6.1.0. Use NidOAuth.requestLogin(context, callback) instead.",
         replaceWith = ReplaceWith("NidOAuth.requestLogin(context, callback)"),
     )
     fun callRefreshAccessTokenApi(callback: NidOAuthCallback) = ioScope.launch {

--- a/Nid-OAuth/src/main/res/values/message.xml
+++ b/Nid-OAuth/src/main/res/values/message.xml
@@ -7,7 +7,7 @@
     <string name="naveroauthlogin_string_network_state_not_available">Network is not available. Please check your network connection and try again.</string>
     <string name="naveroauthlogin_string_msg_naverapp_download_desc">Get NAVER App and sign in faster</string>
     <string name="naveroauthlogin_string_msg_naverapp_download_link">Download App</string>
-    <string name="naveroauthlogin_string_token_invalid">Quick Sign-in account has been expired.</string>
+    <string name="naveroauthlogin_string_token_invalid">Quick Sign-in account has expired.</string>
     <string name="naveroauthlogin_string_group_id_not_available">Group ID can\'t be used to \'Sign in with NAVER\'. Please sign in as a normal account.</string>
     <string name="naveroauthlogin_string_update_naverapp">Please update your Naver app to use this service.</string>
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ## Naver Login Overview
 
-NAVER Login let users to use the OAuth 2.0-based security feature of NAVER when they are using non-NAVER services.
+NAVER Login lets users use the OAuth 2.0-based security feature of NAVER when they are using non-NAVER services.
 
-It is a convenient and secure way for users to log into your application with the NAVER ID and password; they do not have to remember their IDs and password of your application. It is recommended to add NAVER Login to your application if you want to make people who hate complicated signups to join your application or stop users leaving your application because they forget their accounts.
+It is a convenient and secure way for users to log into your application with the NAVER ID and password; they do not have to remember their IDs and password of your application. It is recommended to add NAVER Login to your application if you want to make people who hate complicated signups join your application or stop users leaving your application because they forget their accounts.
 
 ## Naver Login for Android
 
 The NAVER Login library for Android enables you to easily add the login, logout, and token management
 features to your application.
 
-**How to use NaverIdLogin SDK for Android? <small>(korean)</small>**
+**How to use NaverIdLogin SDK for Android? <small>(Korean)</small>**
 - [Refer to Github Wiki](https://github.com/naver/naveridlogin-sdk-android/wiki/%EC%B5%9C%EC%8B%A0%EB%B2%84%EC%A0%84-%EA%B0%80%EC%9D%B4%EB%93%9C)
 - [Naver-Id-Login Android SDK Tutorial Doc](https://developers.naver.com/docs/login/android)
 


### PR DESCRIPTION
## Summary

Fixes a broken `@Deprecated(replaceWith = ...)` quick-fix plus 7 typo/grammar errors in comments, the README and the default English string resource. No functional changes, and no Korean text is touched.

### The main fix: `NaverIdLoginSDK.showDevelopersLog` (behaviour-adjacent, please review closely)

`Nid-OAuth/src/main/java/com/navercorp/nid/NaverIdLoginSDK.kt` L113-114 pointed at two `NidOAuth` members that do not exist, so Android Studio's **"Replace with"** quick-fix on this deprecation emitted code that does not compile:

```kotlin
@Deprecated(
    message = "This method will be removed from v6.1.0. Use NidOAuth.showDevelopersLog(isShow) instead.",
    replaceWith = ReplaceWith("NidOAuth.setLOgEnabled(enabled)"),
)
fun showDevelopersLog(isShow: Boolean) = NidOAuth.setLogEnabled(isShow)
```

- `NidOAuth.setLOgEnabled` (capital **O**) does not exist. The real member is `NidOAuth.setLogEnabled` (`NidOAuth.kt` L239), which is exactly what the function body already delegates to.
- `enabled` is not in scope inside `showDevelopersLog(isShow: Boolean)`. `ReplaceWith` expressions resolve against the deprecated declaration's own parameters, so the argument has to be `isShow` — the same convention the file's other blocks follow (e.g. `ReplaceWith("NidOAuth.requestLogin(context, launcher)")` for `authenticate(context, launcher)`).
- The `message` named `NidOAuth.showDevelopersLog`, which does not exist on `NidOAuth` either — it repeats the deprecated name instead of the replacement.

I checked all 23 `@Deprecated` blocks in `NaverIdLoginSDK.kt` against the real `NidOAuth` members: **22 are internally consistent and resolve correctly; this was the only one that did not.** Both halves are now brought in line with the other 22:

```kotlin
message = "This method will be removed from v6.1.0. Use NidOAuth.setLogEnabled(isShow) instead.",
replaceWith = ReplaceWith("NidOAuth.setLogEnabled(isShow)"),
```

### Other fixes

- **`Nid-OAuth/.../oauth/NidOAuthLogin.kt`** L28: `NidOAuth.requestLogin(cotext, callback)` -> `context`. The `replaceWith` on the very next line already spells it `context`.
- **`Nid-OAuth/.../core/log/ReleaseNidLog.kt`** (6 occurrences): `// Do nothings.` -> `// Do nothing.` The sample sources already use the correct `// do nothing`, so this only makes the repo self-consistent. All 6 are in the same file and identical, so leaving any of them would look arbitrary.
- **`README.md`** L5: "NAVER Login **let users to use**" -> "**lets users use**".
- **`README.md`** L7: "make people who hate complicated signups **to join**" -> "**join**" (causative `make` takes a bare infinitive).
- **`README.md`** L14: `<small>(korean)</small>` -> `<small>(Korean)</small>`.
- **`Nid-OAuth/src/main/res/values/message.xml`**: "Quick Sign-in account **has been expired**." -> "**has expired**." *This is the one user-facing display string in the PR* — it is the default (English) resource only; `values-ko`, `values-zh-rCN` and `values-zh-rTW` are untouched. Happy to drop this hunk if the copy needs to go through your localisation process.

### Deliberately left alone

- **All Korean text**, including `네아로` and the `네아로SDK for Android` README heading.
- **`ERROR_NO_CATAGORIZED`** (`NidOAuthErrorCode.kt`, used across 3 files). This is a misspelling, but it is a public enum constant *and* its `code`/`description` values are the wire string `"no_catagorized_error"`. Renaming it would be a breaking API change and would alter values that go over the network, so it is out of scope for a typo PR.
- **Casing preferences** such as `Api` vs `API`, `Github` vs `GitHub`, and `Naver` vs `NAVER` in `message.xml` — style, not errors.
- Awkward-but-not-incorrect README phrasing ("uses libraries below", "stop users leaving", "their IDs and password").